### PR TITLE
1.2.3 snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Works with generalized arrays.
 
 For more detailed information, please refer to the [API Documentation](https://vickumar1981.github.io/stringdistance/api/com/github/vickumar1981/stringdistance/index.html "API Documentation").
 
-Requires: Java 8+ or Scala 2.12+
+Requires: Java 8+ or Scala 2.11+
 
 ---
 ### Contents
@@ -32,7 +32,7 @@ __Using sbt:__
 
 In `build.sbt`:
 ```scala
-libraryDependencies += "com.github.vickumar1981" %% "stringdistance" % "1.2.2"
+libraryDependencies += "com.github.vickumar1981" %% "stringdistance" % "1.2.3"
 ```
 
 __Using gradle:__
@@ -40,7 +40,7 @@ __Using gradle:__
 In `build.gradle`:
 ```groovy
 dependencies {
-    compile 'com.github.vickumar1981:stringdistance_2.13:1.2.2'
+    compile 'com.github.vickumar1981:stringdistance_2.13:1.2.3'
 }
 ```
 
@@ -51,12 +51,13 @@ In `pom.xml`:
 <dependency>
     <groupId>com.github.vickumar1981</groupId>
     <artifactId>stringdistance_2.13</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
 </dependency>
 ```
 
-**Note:**
- - For Scala 2.12, please use the `stringdistance_2.12` artifact as a dependency instead. 
+**Notes:**
+ - For Scala 2.12, please use the `stringdistance_2.12` artifact as a dependency instead.
+ - For Scala 2.11, please use the `stringdistance_2.11` artifact as a dependency instead. 
 
 ---
 ### 2. Scala Usage

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ publishMavenStyle := true
 licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 pomIncludeRepository := { _ => false }
 publishArtifact in Test := false
-crossScalaVersions := Seq("2.12.8", "2.13.1")
+crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1")
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = false)
 
 // Add sonatype repository settings

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import xerial.sbt.Sonatype._
 
 name := "stringdistance"
-version := "1.2.2"
+version := "1.2.3-SNAPSHOT"
 scalaVersion := "2.13.1"
 organization := "com.github.vickumar1981"
 description := "A fuzzy matching string distance library for Scala and Java."


### PR DESCRIPTION
Addresses issue https://github.com/vickumar1981/stringdistance/issues/50.

`1.2.3` version should work with Scala 2.11, 2.12, and 2.13.