### PR TITLE
More tests for phonetic similarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ![Logo](logo.png)
 
-# Conributing to StringDistance  
+# Contributing to StringDistance  
 
 Thanks for taking the time to contribute!
 

--- a/src/test/scala/fixtures/TestSoundCases.scala
+++ b/src/test/scala/fixtures/TestSoundCases.scala
@@ -11,6 +11,25 @@ object TestSoundCases {
     TestSoundCase("dumb", "gum", Some(false), Some(false)),
     TestSoundCase("", "abc", Some(false), Some(false)),
     TestSoundCase("robert", "rupert", Some(false), Some(true)),
-    TestSoundCase("robert", "rubin", Some(false), Some(false))
+    TestSoundCase("robert", "rubin", Some(false), Some(false)),
+    TestSoundCase("night", "knight", Some(true), Some(false)),
+    TestSoundCase("isle", "aisle", Some(false), Some(false)),
+    TestSoundCase("pair", "pear", Some(true), Some(true)),
+    TestSoundCase("site", "cite", Some(true), Some(false)),
+    TestSoundCase("sight", "cite", Some(false), Some(false)),
+    TestSoundCase("science", "seance", Some(true), Some(true)),
+    TestSoundCase("wretch", "retch", Some(true), Some(false)),
+    TestSoundCase("bathhouses", "bathowses", Some(true), Some(true)),
+    TestSoundCase("box", "balks", Some(false), Some(false)),
+    TestSoundCase("eve", "eave", Some(true), Some(true)),
+    TestSoundCase("does", "doze", Some(true), Some(true)),
+    TestSoundCase("oh", "owe", Some(false), Some(true)),
+    TestSoundCase("washhouse", "watchhouse", Some(true), Some(false)),
+    TestSoundCase("aha", "haha", Some(false), Some(false)),
+    TestSoundCase("hodge", "hoge", Some(false), Some(false)),
+    TestSoundCase("xanax", "zanax", Some(true), Some(false)),
+    TestSoundCase("whirl", "wiril", Some(true), Some(true)),
+    TestSoundCase("squirrel", "skwerl", Some(false), Some(true)),
+    TestSoundCase("lackey", "lakie", Some(true), Some(true))
   )
 }


### PR DESCRIPTION
(Partially) addresses #8 

This PR adds more test cases for the Metaphone and Soundex algorithms, bringing the code coverage for the `sound` package from 50.58% to 84.38%. This is still short of the 99% required for Scoverage acceptance, so the package was not removed from the exclusion list.

Each test case added was verified to be correct using the following online tools:
https://en.toolpage.org/tool/metaphone
https://en.toolpage.org/tool/soundex