### PR TITLE
Add some extra TestSoundCases

### DIFF
--- a/src/main/scala/com/github/vickumar1981/stringdistance/impl/sound/MetaphoneImpl.scala
+++ b/src/main/scala/com/github/vickumar1981/stringdistance/impl/sound/MetaphoneImpl.scala
@@ -4,12 +4,12 @@ import com.github.vickumar1981.stringdistance.interfaces.sound.MetaphoneAlgo
 import com.github.vickumar1981.stringdistance.interfaces.sound.CommonSoundAlgo._
 
 private[stringdistance] trait MetaphoneImpl {
-  private def compare(a: Array[Char], b: Array[Char]): Option[Boolean] =
+  private def compare(a: String, b: String): Option[Boolean] =
     if (a.length == 0 || !isAlpha(a.head) || b.length == 0 || !isAlpha(b.head)) None
     else MetaphoneAlgo.compute(a).filter(_.length > 0).flatMap { mp1 =>
       MetaphoneAlgo.compute(b).filter(_.length > 0).map(mp1.sameElements(_))
     }
 
   protected def metaphone(s1: String, s2: String): Boolean =
-    compare(s1.toCharArray, s2.toCharArray).getOrElse(false)
+    compare(s1, s2).getOrElse(false)
 }

--- a/src/main/scala/com/github/vickumar1981/stringdistance/impl/sound/SoundexImpl.scala
+++ b/src/main/scala/com/github/vickumar1981/stringdistance/impl/sound/SoundexImpl.scala
@@ -4,7 +4,7 @@ import com.github.vickumar1981.stringdistance.interfaces.sound.CommonSoundAlgo._
 import com.github.vickumar1981.stringdistance.interfaces.sound.SoundexAlgo
 
 private[stringdistance] trait SoundexImpl {
-  private def compare(a: Array[Char], b: Array[Char]): Option[Boolean] =
+  private def compare(a: String, b: String): Option[Boolean] =
     if (a.length == 0 || !isAlpha(a.head) || b.length == 0 || !isAlpha(b.head)) None
     else if (a.head.toLower != b.head.toLower) Some(false)
     else SoundexAlgo.compute(a).filter(_.length > 0).flatMap { se1 =>
@@ -12,5 +12,5 @@ private[stringdistance] trait SoundexImpl {
     }
 
   protected def soundex(a: String, b: String): Boolean =
-    compare(a.toCharArray, b.toCharArray).getOrElse(false)
+    compare(a, b).getOrElse(false)
 }

--- a/src/test/scala/fixtures/TestSoundCases.scala
+++ b/src/test/scala/fixtures/TestSoundCases.scala
@@ -10,6 +10,7 @@ object TestSoundCases {
     TestSoundCase("merci", "mercy", Some(true), Some(true)),
     TestSoundCase("dumb", "gum", Some(false), Some(false)),
     TestSoundCase("", "abc", Some(false), Some(false)),
+    TestSoundCase("abc", "", Some(false), Some(false)),
     TestSoundCase("robert", "rupert", Some(false), Some(true)),
     TestSoundCase("robert", "rubin", Some(false), Some(false)),
     TestSoundCase("night", "knight", Some(true), Some(false)),
@@ -30,6 +31,14 @@ object TestSoundCases {
     TestSoundCase("xanax", "zanax", Some(true), Some(false)),
     TestSoundCase("whirl", "wiril", Some(true), Some(true)),
     TestSoundCase("squirrel", "skwerl", Some(false), Some(true)),
-    TestSoundCase("lackey", "lakie", Some(true), Some(true))
+    TestSoundCase("lackey", "lakie", Some(true), Some(true)),
+    TestSoundCase("hanma", "hammer", Some(false), Some(false)),
+    TestSoundCase("abbot", "about", Some(true), Some(true)),
+    TestSoundCase("x", "s", Some(true), Some(false)),
+    TestSoundCase("why", "y", Some(false), Some(false)),
+    TestSoundCase("aeon", "eon", Some(true), Some(false)),
+    TestSoundCase("dodgy", "dodge", Some(true), Some(true)),
+    TestSoundCase("edgy", "wedgie", Some(false), Some(false)),
+    TestSoundCase("caça", "cassa", Some(false), Some(false))
   )
 }


### PR DESCRIPTION
Adds some extra test sound cases to increase the test coverage.

This brings the `SoundexAlgo` coverage close to 100%, but unfortunately I don't know enough about the algorithm to trigger the missing edge cases.

This also improves the `MetaphoneAlgo` coverage, but again, since I'm not very familiar with the algorithm, it's hard to generate the edge cases.

I also removed a `String` -> `Array[Char]` conversion to improve the test coverage. I also think that this might slightly improve performance (since the conversion happens later, and only if needed), but I haven't benchmarked it.