### PR TITLE
JMH benchmarks

### DIFF
--- a/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
+++ b/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
@@ -1,0 +1,110 @@
+package com.github.vickumar1981.stringdistance
+
+import org.openjdk.jmh.annotations.Benchmark
+import ArrayDistanceBenchmarks._
+
+class ArrayDistanceBenchmarks {
+  @Benchmark
+  def emptyCosineTest(): Unit = emptyArrScoreTest(ArrayDistance.Cosine)
+  @Benchmark
+  def smallDiffCosineTest(): Unit = smallDiffArrScoreTest(ArrayDistance.Cosine)
+  @Benchmark
+  def smallSameCosineTest(): Unit = smallSameArrScoreTest(ArrayDistance.Cosine)
+  @Benchmark
+  def largeDiffCosineTest(): Unit = largeDiffArrScoreTest(ArrayDistance.Cosine)
+  @Benchmark
+  def largeSameCosineTest(): Unit = largeSameArrScoreTest(ArrayDistance.Cosine)
+
+  // Missing: Damerau
+
+  @Benchmark
+  def emptyDiceCoefficientTest(): Unit = emptyArrScoreTest(ArrayDistance.DiceCoefficient)
+  @Benchmark
+  def smallDiffDiceCoefficientTest(): Unit = smallDiffArrScoreTest(ArrayDistance.DiceCoefficient)
+  @Benchmark
+  def smallSameDiceCoefficientTest(): Unit = smallSameArrScoreTest(ArrayDistance.DiceCoefficient)
+  @Benchmark
+  def largeDiffDiceCoefficientTest(): Unit = largeDiffArrScoreTest(ArrayDistance.DiceCoefficient)
+  @Benchmark
+  def largeSameDiceCoefficientTest(): Unit = largeSameArrScoreTest(ArrayDistance.DiceCoefficient)
+
+  // Missing: Hamming
+
+  // Missing: Jaccard
+
+  @Benchmark
+  def emptyJaroTest(): Unit = emptyArrScoreTest(ArrayDistance.Jaro)
+  @Benchmark
+  def smallDiffJaroTest(): Unit = smallDiffArrScoreTest(ArrayDistance.Jaro)
+  @Benchmark
+  def smallSameJaroTest(): Unit = smallSameArrScoreTest(ArrayDistance.Jaro)
+  @Benchmark
+  def largeDiffJaroTest(): Unit = largeDiffArrScoreTest(ArrayDistance.Jaro)
+  @Benchmark
+  def largeSameJaroTest(): Unit = largeSameArrScoreTest(ArrayDistance.Jaro)
+
+  @Benchmark
+  def emptyLongestCommonSeqTest(): Unit = emptyArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  @Benchmark
+  def smallDiffLongestCommonSeqTest(): Unit = smallDiffArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  @Benchmark
+  def smallSameLongestCommonSeqTest(): Unit = smallSameArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  /*@Benchmark
+  def largeDiffLongestCommonSeqTest(): Unit = largeDiffArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  @Benchmark
+  def largeSameLongestCommonSeqTest(): Unit = largeSameArrDistanceTest(ArrayDistance.LongestCommonSeq)*/
+
+  // Missing: NeedlemanWunsch
+
+  // Missing: NGram
+  
+  // Missing: Overlap
+  
+  // Missing: SmithWaterman
+  
+  // Missing: SmithWatermanGotoh
+  
+  // Missing: Tversy
+}
+
+object ArrayDistanceBenchmarks {
+  def testScoreMetric[T](
+    arr1: Array[T],
+    arr2: Array[T]
+  )(scoreMetric: ArrayDistance.ScoreMetric): Unit =
+    scoreMetric.score(arr1, arr2)
+
+  def testDistanceMetric[T](
+    arr1: Array[T],
+    arr2: Array[T]
+  )(distanceMetric: ArrayDistance.DistanceMetric): Unit =
+    distanceMetric.distance(arr1, arr2)
+
+  val emptyArrScoreTest = testScoreMetric(Array.empty[Int], Array.empty[Int]) _
+  val smallDiffArrScoreTest = testScoreMetric(
+    Array.fill(10)('a'),
+    Array.fill(10)('b')) _
+  val smallSameArrScoreTest = testScoreMetric(
+    Array.fill(10)('a'),
+    Array.fill(10)('a')) _
+  val largeDiffArrScoreTest = testScoreMetric(
+    Array.fill(50)('a'),
+    Array.fill(50)('b')) _
+  val largeSameArrScoreTest = testScoreMetric(
+    Array.fill(50)('a'),
+    Array.fill(50)('a')) _
+
+  val emptyArrDistanceTest = testDistanceMetric(Array.empty[Int], Array.empty[Int]) _
+  val smallDiffArrDistanceTest = testDistanceMetric(
+    Array.fill(10)('a'),
+    Array.fill(10)('b')) _
+  val smallSameArrDistanceTest = testDistanceMetric(
+    Array.fill(10)('a'),
+    Array.fill(10)('a')) _
+  val largeDiffArrDistanceTest = testDistanceMetric(
+    Array.fill(50)('a'),
+    Array.fill(50)('b')) _
+  val largeSameArrDistanceTest = testDistanceMetric(
+    Array.fill(50)('a'),
+    Array.fill(50)('a')) _
+}

--- a/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
+++ b/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
@@ -95,22 +95,30 @@ class ArrayDistanceBenchmarks {
   def largeSameNeedlemanWunschTest(): Unit = largeSameArrTest(ArrayDistance.NeedlemanWunsch)
 
   @Benchmark
-  def smallDiffNGramDistTest(): Unit = smallDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  def smallDiffNGramDistTest(): Unit =
+    smallDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
   @Benchmark
-  def smallSameNGramDistTest(): Unit = smallSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  def smallSameNGramDistTest(): Unit =
+    smallSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
   @Benchmark
-  def largeDiffNGramDistTest(): Unit = largeDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  def largeDiffNGramDistTest(): Unit =
+    largeDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
   @Benchmark
-  def largeSameNGramDistTest(): Unit = largeSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  def largeSameNGramDistTest(): Unit =
+    largeSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
 
   @Benchmark
-  def smallDiffNGramScoreTest(): Unit = smallDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  def smallDiffNGramScoreTest(): Unit =
+    smallDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
   @Benchmark
-  def smallSameNGramScoreTest(): Unit = smallSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  def smallSameNGramScoreTest(): Unit =
+    smallSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
   @Benchmark
-  def largeDiffNGramScoreTest(): Unit = largeDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  def largeDiffNGramScoreTest(): Unit =
+    largeDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
   @Benchmark
-  def largeSameNGramScoreTest(): Unit = largeSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  def largeSameNGramScoreTest(): Unit =
+    largeSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
 
   @Benchmark
   def smallDiffOverlapTest(): Unit = smallDiffArrTest(ArrayDistance.Overlap)
@@ -120,7 +128,7 @@ class ArrayDistanceBenchmarks {
   def largeDiffOverlapTest(): Unit = largeDiffArrTest(ArrayDistance.Overlap)
   @Benchmark
   def largeSameOverlapTest(): Unit = largeSameArrTest(ArrayDistance.Overlap)
-  
+
   @Benchmark
   def smallDiffSmithWatermanTest(): Unit = smallDiffArrTest(ArrayDistance.SmithWaterman)
   @Benchmark
@@ -129,7 +137,7 @@ class ArrayDistanceBenchmarks {
   def largeDiffSmithWatermanTest(): Unit = largeDiffArrTest(ArrayDistance.SmithWaterman)
   @Benchmark
   def largeSameSmithWatermanTest(): Unit = largeSameArrTest(ArrayDistance.SmithWaterman)
-  
+
   @Benchmark
   def smallDiffSmithWatermanGotohTest(): Unit = smallDiffArrTest(ArrayDistance.SmithWatermanGotoh)
   @Benchmark
@@ -138,7 +146,7 @@ class ArrayDistanceBenchmarks {
   def largeDiffSmithWatermanGotohTest(): Unit = largeDiffArrTest(ArrayDistance.SmithWatermanGotoh)
   @Benchmark
   def largeSameSmithWatermanGotohTest(): Unit = largeSameArrTest(ArrayDistance.SmithWatermanGotoh)
-  
+
   @Benchmark
   def smallDiffTverskyTest(): Unit = smallDiffArrTest(ArrayDistance.Tversky)
   @Benchmark
@@ -159,45 +167,42 @@ object ArrayDistanceBenchmarks {
     def apply[T](implicit bench: Bench[T]): Bench[T] = bench
   }
 
-  implicit def scoreMetricBenchmarkable[T <: ArrayDistance.ScoreMetric] = new Bench[T] {
-    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
-      metric.score(arr1, arr2)
-  }
+  implicit def scoreMetricBenchmarkable[T <: ArrayDistance.ScoreMetric] =
+    new Bench[T] {
+      def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+        metric.score(arr1, arr2)
+    }
 
-  implicit def distanceMetricBenchmarkable[T <: ArrayDistance.DistanceMetric] = new Bench[T] {
-    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
-      metric.distance(arr1, arr2)
-  }
+  implicit def distanceMetricBenchmarkable[T <: ArrayDistance.DistanceMetric] =
+    new Bench[T] {
+      def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+        metric.distance(arr1, arr2)
+    }
 
-  implicit def weightedScoreMetricBenchmarkable[T <: ArrayDistance.WeightedScoreMetric[_]] = new Bench[T] {
-    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
-      metric.score(arr1, arr2)
-  }
+  implicit def weightedScoreMetricBenchmarkable[T <: ArrayDistance.WeightedScoreMetric[_]] =
+    new Bench[T] {
+      def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+        metric.score(arr1, arr2)
+    }
 
-  implicit def weightedDistanceMetricBenchmarkable[T <: ArrayDistance.WeightedDistanceMetric[_]] = new Bench[T] {
-    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
-      metric.distance(arr1, arr2)
-  }
+  implicit def weightedDistanceMetricBenchmarkable[T <: ArrayDistance.WeightedDistanceMetric[_]] =
+    new Bench[T] {
+      def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+        metric.distance(arr1, arr2)
+    }
 
-  implicit def scoreFromDistanceMetricBenchmarkable[T <: ArrayDistance.ScoreFromDistanceMetric] = new Bench[T] {
-    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
-      metric.distance(arr1, arr2)
-  }
+  implicit def scoreFromDistanceMetricBenchmarkable[T <: ArrayDistance.ScoreFromDistanceMetric] =
+    new Bench[T] {
+      def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+        metric.distance(arr1, arr2)
+    }
 
-  def smallDiffArrTest[T: Bench](metric: T) = Bench[T].benchmark(
-    Array.fill(10)('a'),
-    Array.fill(10)('b'),
-    metric)
-  def smallSameArrTest[T: Bench](metric: T) = Bench[T].benchmark(
-    Array.fill(10)('a'),
-    Array.fill(10)('a'),
-    metric)
-  def largeDiffArrTest[T: Bench](metric: T) = Bench[T].benchmark(
-    Array.fill(50)('a'),
-    Array.fill(50)('b'),
-    metric)
-  def largeSameArrTest[T: Bench](metric: T) = Bench[T].benchmark(
-    Array.fill(50)('a'),
-    Array.fill(50)('a'),
-    metric)
+  def smallDiffArrTest[T: Bench](metric: T) =
+    Bench[T].benchmark(Array.fill(10)('a'), Array.fill(10)('b'), metric)
+  def smallSameArrTest[T: Bench](metric: T) =
+    Bench[T].benchmark(Array.fill(10)('a'), Array.fill(10)('a'), metric)
+  def largeDiffArrTest[T: Bench](metric: T) =
+    Bench[T].benchmark(Array.fill(50)('a'), Array.fill(50)('b'), metric)
+  def largeSameArrTest[T: Bench](metric: T) =
+    Bench[T].benchmark(Array.fill(50)('a'), Array.fill(50)('a'), metric)
 }

--- a/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
+++ b/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
@@ -5,8 +5,6 @@ import ArrayDistanceBenchmarks._
 
 class ArrayDistanceBenchmarks {
   @Benchmark
-  def emptyCosineTest(): Unit = emptyArrTest(ArrayDistance.Cosine)
-  @Benchmark
   def smallDiffCosineTest(): Unit = smallDiffArrTest(ArrayDistance.Cosine)
   @Benchmark
   def smallSameCosineTest(): Unit = smallSameArrTest(ArrayDistance.Cosine)
@@ -15,8 +13,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameCosineTest(): Unit = largeSameArrTest(ArrayDistance.Cosine)
 
-  @Benchmark
-  def emptyDamerauTest(): Unit = emptyArrTest(ArrayDistance.Damerau)
   @Benchmark
   def smallDiffDamerauTest(): Unit = smallDiffArrTest(ArrayDistance.Damerau)
   @Benchmark
@@ -27,8 +23,6 @@ class ArrayDistanceBenchmarks {
   def largeSameDamerauTest(): Unit = largeSameArrTest(ArrayDistance.Damerau)
 
   @Benchmark
-  def emptyDiceCoefficientTest(): Unit = emptyArrTest(ArrayDistance.DiceCoefficient)
-  @Benchmark
   def smallDiffDiceCoefficientTest(): Unit = smallDiffArrTest(ArrayDistance.DiceCoefficient)
   @Benchmark
   def smallSameDiceCoefficientTest(): Unit = smallSameArrTest(ArrayDistance.DiceCoefficient)
@@ -37,8 +31,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameDiceCoefficientTest(): Unit = largeSameArrTest(ArrayDistance.DiceCoefficient)
 
-  @Benchmark
-  def emptyHammingTest(): Unit = emptyArrTest(ArrayDistance.Hamming)
   @Benchmark
   def smallDiffHammingTest(): Unit = smallDiffArrTest(ArrayDistance.Hamming)
   @Benchmark
@@ -49,8 +41,6 @@ class ArrayDistanceBenchmarks {
   def largeSameHammingTest(): Unit = largeSameArrTest(ArrayDistance.Hamming)
 
   @Benchmark
-  def emptyJaccardTest(): Unit = emptyArrTest(ArrayDistance.Jaccard)
-  @Benchmark
   def smallDiffJaccardTest(): Unit = smallDiffArrTest(ArrayDistance.Jaccard)
   @Benchmark
   def smallSameJaccardTest(): Unit = smallSameArrTest(ArrayDistance.Jaccard)
@@ -59,8 +49,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameJaccardTest(): Unit = largeSameArrTest(ArrayDistance.Jaccard)
 
-  @Benchmark
-  def emptyJaroTest(): Unit = emptyArrTest(ArrayDistance.Jaro)
   @Benchmark
   def smallDiffJaroTest(): Unit = smallDiffArrTest(ArrayDistance.Jaro)
   @Benchmark
@@ -71,8 +59,6 @@ class ArrayDistanceBenchmarks {
   def largeSameJaroTest(): Unit = largeSameArrTest(ArrayDistance.Jaro)
 
   @Benchmark
-  def emptyJaroWinklerTest(): Unit = emptyArrTest(ArrayDistance.JaroWinkler)
-  @Benchmark
   def smallDiffJaroWinklerTest(): Unit = smallDiffArrTest(ArrayDistance.JaroWinkler)
   @Benchmark
   def smallSameJaroWinklerTest(): Unit = smallSameArrTest(ArrayDistance.JaroWinkler)
@@ -81,8 +67,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameJaroWinklerTest(): Unit = largeSameArrTest(ArrayDistance.JaroWinkler)
 
-  @Benchmark
-  def emptyLevenshteinTest(): Unit = emptyArrTest(ArrayDistance.Levenshtein)
   @Benchmark
   def smallDiffLevenshteinTest(): Unit = smallDiffArrTest(ArrayDistance.Levenshtein)
   @Benchmark
@@ -93,8 +77,6 @@ class ArrayDistanceBenchmarks {
   def largeSameLevenshteinTest(): Unit = largeSameArrTest(ArrayDistance.Levenshtein)
 
   @Benchmark
-  def emptyLongestCommonSeqTest(): Unit = emptyArrTest(ArrayDistance.LongestCommonSeq)
-  @Benchmark
   def smallDiffLongestCommonSeqTest(): Unit = smallDiffArrTest(ArrayDistance.LongestCommonSeq)
   @Benchmark
   def smallSameLongestCommonSeqTest(): Unit = smallSameArrTest(ArrayDistance.LongestCommonSeq)
@@ -103,8 +85,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameLongestCommonSeqTest(): Unit = largeSameArrTest(ArrayDistance.LongestCommonSeq)*/
 
-  @Benchmark
-  def emptyNeedlemanWunschTest(): Unit = emptyArrTest(ArrayDistance.NeedlemanWunsch)
   @Benchmark
   def smallDiffNeedlemanWunschTest(): Unit = smallDiffArrTest(ArrayDistance.NeedlemanWunsch)
   @Benchmark
@@ -115,8 +95,6 @@ class ArrayDistanceBenchmarks {
   def largeSameNeedlemanWunschTest(): Unit = largeSameArrTest(ArrayDistance.NeedlemanWunsch)
 
   @Benchmark
-  def emptyNGramDistTest(): Unit = emptyArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
-  @Benchmark
   def smallDiffNGramDistTest(): Unit = smallDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
   @Benchmark
   def smallSameNGramDistTest(): Unit = smallSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
@@ -125,8 +103,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameNGramDistTest(): Unit = largeSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
 
-  @Benchmark
-  def emptyNGramScoreTest(): Unit = emptyArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
   @Benchmark
   def smallDiffNGramScoreTest(): Unit = smallDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
   @Benchmark
@@ -137,8 +113,6 @@ class ArrayDistanceBenchmarks {
   def largeSameNGramScoreTest(): Unit = largeSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
 
   @Benchmark
-  def emptyOverlapTest(): Unit = emptyArrTest(ArrayDistance.Overlap)
-  @Benchmark
   def smallDiffOverlapTest(): Unit = smallDiffArrTest(ArrayDistance.Overlap)
   @Benchmark
   def smallSameOverlapTest(): Unit = smallSameArrTest(ArrayDistance.Overlap)
@@ -147,8 +121,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameOverlapTest(): Unit = largeSameArrTest(ArrayDistance.Overlap)
   
-  @Benchmark
-  def emptySmithWatermanTest(): Unit = emptyArrTest(ArrayDistance.SmithWaterman)
   @Benchmark
   def smallDiffSmithWatermanTest(): Unit = smallDiffArrTest(ArrayDistance.SmithWaterman)
   @Benchmark
@@ -159,8 +131,6 @@ class ArrayDistanceBenchmarks {
   def largeSameSmithWatermanTest(): Unit = largeSameArrTest(ArrayDistance.SmithWaterman)
   
   @Benchmark
-  def emptySmithWatermanGotohTest(): Unit = emptyArrTest(ArrayDistance.SmithWatermanGotoh)
-  @Benchmark
   def smallDiffSmithWatermanGotohTest(): Unit = smallDiffArrTest(ArrayDistance.SmithWatermanGotoh)
   @Benchmark
   def smallSameSmithWatermanGotohTest(): Unit = smallSameArrTest(ArrayDistance.SmithWatermanGotoh)
@@ -169,8 +139,6 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameSmithWatermanGotohTest(): Unit = largeSameArrTest(ArrayDistance.SmithWatermanGotoh)
   
-  @Benchmark
-  def emptyTverskyTest(): Unit = emptyArrTest(ArrayDistance.Tversky)
   @Benchmark
   def smallDiffTverskyTest(): Unit = smallDiffArrTest(ArrayDistance.Tversky)
   @Benchmark
@@ -216,8 +184,6 @@ object ArrayDistanceBenchmarks {
       metric.distance(arr1, arr2)
   }
 
-  def emptyArrTest[T: Bench](metric: T) =
-    Bench[T].benchmark(Array.empty[Int], Array.empty[Int], metric)
   def smallDiffArrTest[T: Bench](metric: T) = Bench[T].benchmark(
     Array.fill(10)('a'),
     Array.fill(10)('b'),

--- a/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
+++ b/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
@@ -5,54 +5,54 @@ import ArrayDistanceBenchmarks._
 
 class ArrayDistanceBenchmarks {
   @Benchmark
-  def emptyCosineTest(): Unit = emptyArrScoreTest(ArrayDistance.Cosine)
+  def emptyCosineTest(): Unit = emptyArrTest(ArrayDistance.Cosine)
   @Benchmark
-  def smallDiffCosineTest(): Unit = smallDiffArrScoreTest(ArrayDistance.Cosine)
+  def smallDiffCosineTest(): Unit = smallDiffArrTest(ArrayDistance.Cosine)
   @Benchmark
-  def smallSameCosineTest(): Unit = smallSameArrScoreTest(ArrayDistance.Cosine)
+  def smallSameCosineTest(): Unit = smallSameArrTest(ArrayDistance.Cosine)
   @Benchmark
-  def largeDiffCosineTest(): Unit = largeDiffArrScoreTest(ArrayDistance.Cosine)
+  def largeDiffCosineTest(): Unit = largeDiffArrTest(ArrayDistance.Cosine)
   @Benchmark
-  def largeSameCosineTest(): Unit = largeSameArrScoreTest(ArrayDistance.Cosine)
+  def largeSameCosineTest(): Unit = largeSameArrTest(ArrayDistance.Cosine)
 
   // Missing: Damerau
 
   @Benchmark
-  def emptyDiceCoefficientTest(): Unit = emptyArrScoreTest(ArrayDistance.DiceCoefficient)
+  def emptyDiceCoefficientTest(): Unit = emptyArrTest(ArrayDistance.DiceCoefficient)
   @Benchmark
-  def smallDiffDiceCoefficientTest(): Unit = smallDiffArrScoreTest(ArrayDistance.DiceCoefficient)
+  def smallDiffDiceCoefficientTest(): Unit = smallDiffArrTest(ArrayDistance.DiceCoefficient)
   @Benchmark
-  def smallSameDiceCoefficientTest(): Unit = smallSameArrScoreTest(ArrayDistance.DiceCoefficient)
+  def smallSameDiceCoefficientTest(): Unit = smallSameArrTest(ArrayDistance.DiceCoefficient)
   @Benchmark
-  def largeDiffDiceCoefficientTest(): Unit = largeDiffArrScoreTest(ArrayDistance.DiceCoefficient)
+  def largeDiffDiceCoefficientTest(): Unit = largeDiffArrTest(ArrayDistance.DiceCoefficient)
   @Benchmark
-  def largeSameDiceCoefficientTest(): Unit = largeSameArrScoreTest(ArrayDistance.DiceCoefficient)
+  def largeSameDiceCoefficientTest(): Unit = largeSameArrTest(ArrayDistance.DiceCoefficient)
 
   // Missing: Hamming
 
   // Missing: Jaccard
 
   @Benchmark
-  def emptyJaroTest(): Unit = emptyArrScoreTest(ArrayDistance.Jaro)
+  def emptyJaroTest(): Unit = emptyArrTest(ArrayDistance.Jaro)
   @Benchmark
-  def smallDiffJaroTest(): Unit = smallDiffArrScoreTest(ArrayDistance.Jaro)
+  def smallDiffJaroTest(): Unit = smallDiffArrTest(ArrayDistance.Jaro)
   @Benchmark
-  def smallSameJaroTest(): Unit = smallSameArrScoreTest(ArrayDistance.Jaro)
+  def smallSameJaroTest(): Unit = smallSameArrTest(ArrayDistance.Jaro)
   @Benchmark
-  def largeDiffJaroTest(): Unit = largeDiffArrScoreTest(ArrayDistance.Jaro)
+  def largeDiffJaroTest(): Unit = largeDiffArrTest(ArrayDistance.Jaro)
   @Benchmark
-  def largeSameJaroTest(): Unit = largeSameArrScoreTest(ArrayDistance.Jaro)
+  def largeSameJaroTest(): Unit = largeSameArrTest(ArrayDistance.Jaro)
 
   @Benchmark
-  def emptyLongestCommonSeqTest(): Unit = emptyArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  def emptyLongestCommonSeqTest(): Unit = emptyArrTest(ArrayDistance.LongestCommonSeq)
   @Benchmark
-  def smallDiffLongestCommonSeqTest(): Unit = smallDiffArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  def smallDiffLongestCommonSeqTest(): Unit = smallDiffArrTest(ArrayDistance.LongestCommonSeq)
   @Benchmark
-  def smallSameLongestCommonSeqTest(): Unit = smallSameArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  def smallSameLongestCommonSeqTest(): Unit = smallSameArrTest(ArrayDistance.LongestCommonSeq)
   /*@Benchmark
-  def largeDiffLongestCommonSeqTest(): Unit = largeDiffArrDistanceTest(ArrayDistance.LongestCommonSeq)
+  def largeDiffLongestCommonSeqTest(): Unit = largeDiffArrTest(ArrayDistance.LongestCommonSeq)
   @Benchmark
-  def largeSameLongestCommonSeqTest(): Unit = largeSameArrDistanceTest(ArrayDistance.LongestCommonSeq)*/
+  def largeSameLongestCommonSeqTest(): Unit = largeSameArrTest(ArrayDistance.LongestCommonSeq)*/
 
   // Missing: NeedlemanWunsch
 
@@ -68,43 +68,41 @@ class ArrayDistanceBenchmarks {
 }
 
 object ArrayDistanceBenchmarks {
-  def testScoreMetric[T](
-    arr1: Array[T],
-    arr2: Array[T]
-  )(scoreMetric: ArrayDistance.ScoreMetric): Unit =
-    scoreMetric.score(arr1, arr2)
 
-  def testDistanceMetric[T](
-    arr1: Array[T],
-    arr2: Array[T]
-  )(distanceMetric: ArrayDistance.DistanceMetric): Unit =
-    distanceMetric.distance(arr1, arr2)
+  trait Bench[T] {
+    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit
+  }
 
-  val emptyArrScoreTest = testScoreMetric(Array.empty[Int], Array.empty[Int]) _
-  val smallDiffArrScoreTest = testScoreMetric(
-    Array.fill(10)('a'),
-    Array.fill(10)('b')) _
-  val smallSameArrScoreTest = testScoreMetric(
-    Array.fill(10)('a'),
-    Array.fill(10)('a')) _
-  val largeDiffArrScoreTest = testScoreMetric(
-    Array.fill(50)('a'),
-    Array.fill(50)('b')) _
-  val largeSameArrScoreTest = testScoreMetric(
-    Array.fill(50)('a'),
-    Array.fill(50)('a')) _
+  object Bench {
+    def apply[T](implicit bench: Bench[T]): Bench[T] = bench
+  }
 
-  val emptyArrDistanceTest = testDistanceMetric(Array.empty[Int], Array.empty[Int]) _
-  val smallDiffArrDistanceTest = testDistanceMetric(
+  implicit def scoreMetricBenchmarkable[T <: ArrayDistance.ScoreMetric] = new Bench[T] {
+    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+      metric.score(arr1, arr2)
+  }
+
+  implicit def distanceMetricBenchmarkable[T <: ArrayDistance.DistanceMetric] = new Bench[T] {
+    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+      metric.distance(arr1, arr2)
+  }
+
+  def emptyArrTest[T: Bench](metric: T) =
+    Bench[T].benchmark(Array.empty[Int], Array.empty[Int], metric)
+  def smallDiffArrTest[T: Bench](metric: T) = Bench[T].benchmark(
     Array.fill(10)('a'),
-    Array.fill(10)('b')) _
-  val smallSameArrDistanceTest = testDistanceMetric(
+    Array.fill(10)('b'),
+    metric)
+  def smallSameArrTest[T: Bench](metric: T) = Bench[T].benchmark(
     Array.fill(10)('a'),
-    Array.fill(10)('a')) _
-  val largeDiffArrDistanceTest = testDistanceMetric(
+    Array.fill(10)('a'),
+    metric)
+  def largeDiffArrTest[T: Bench](metric: T) = Bench[T].benchmark(
     Array.fill(50)('a'),
-    Array.fill(50)('b')) _
-  val largeSameArrDistanceTest = testDistanceMetric(
+    Array.fill(50)('b'),
+    metric)
+  def largeSameArrTest[T: Bench](metric: T) = Bench[T].benchmark(
     Array.fill(50)('a'),
-    Array.fill(50)('a')) _
+    Array.fill(50)('a'),
+    metric)
 }

--- a/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
+++ b/bench/src/main/scala/com/github/vickumar1981/stringdistance/ArrayDistanceBenchmarks.scala
@@ -15,7 +15,16 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameCosineTest(): Unit = largeSameArrTest(ArrayDistance.Cosine)
 
-  // Missing: Damerau
+  @Benchmark
+  def emptyDamerauTest(): Unit = emptyArrTest(ArrayDistance.Damerau)
+  @Benchmark
+  def smallDiffDamerauTest(): Unit = smallDiffArrTest(ArrayDistance.Damerau)
+  @Benchmark
+  def smallSameDamerauTest(): Unit = smallSameArrTest(ArrayDistance.Damerau)
+  @Benchmark
+  def largeDiffDamerauTest(): Unit = largeDiffArrTest(ArrayDistance.Damerau)
+  @Benchmark
+  def largeSameDamerauTest(): Unit = largeSameArrTest(ArrayDistance.Damerau)
 
   @Benchmark
   def emptyDiceCoefficientTest(): Unit = emptyArrTest(ArrayDistance.DiceCoefficient)
@@ -28,9 +37,27 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameDiceCoefficientTest(): Unit = largeSameArrTest(ArrayDistance.DiceCoefficient)
 
-  // Missing: Hamming
+  @Benchmark
+  def emptyHammingTest(): Unit = emptyArrTest(ArrayDistance.Hamming)
+  @Benchmark
+  def smallDiffHammingTest(): Unit = smallDiffArrTest(ArrayDistance.Hamming)
+  @Benchmark
+  def smallSameHammingTest(): Unit = smallSameArrTest(ArrayDistance.Hamming)
+  @Benchmark
+  def largeDiffHammingTest(): Unit = largeDiffArrTest(ArrayDistance.Hamming)
+  @Benchmark
+  def largeSameHammingTest(): Unit = largeSameArrTest(ArrayDistance.Hamming)
 
-  // Missing: Jaccard
+  @Benchmark
+  def emptyJaccardTest(): Unit = emptyArrTest(ArrayDistance.Jaccard)
+  @Benchmark
+  def smallDiffJaccardTest(): Unit = smallDiffArrTest(ArrayDistance.Jaccard)
+  @Benchmark
+  def smallSameJaccardTest(): Unit = smallSameArrTest(ArrayDistance.Jaccard)
+  @Benchmark
+  def largeDiffJaccardTest(): Unit = largeDiffArrTest(ArrayDistance.Jaccard)
+  @Benchmark
+  def largeSameJaccardTest(): Unit = largeSameArrTest(ArrayDistance.Jaccard)
 
   @Benchmark
   def emptyJaroTest(): Unit = emptyArrTest(ArrayDistance.Jaro)
@@ -44,6 +71,28 @@ class ArrayDistanceBenchmarks {
   def largeSameJaroTest(): Unit = largeSameArrTest(ArrayDistance.Jaro)
 
   @Benchmark
+  def emptyJaroWinklerTest(): Unit = emptyArrTest(ArrayDistance.JaroWinkler)
+  @Benchmark
+  def smallDiffJaroWinklerTest(): Unit = smallDiffArrTest(ArrayDistance.JaroWinkler)
+  @Benchmark
+  def smallSameJaroWinklerTest(): Unit = smallSameArrTest(ArrayDistance.JaroWinkler)
+  @Benchmark
+  def largeDiffJaroWinklerTest(): Unit = largeDiffArrTest(ArrayDistance.JaroWinkler)
+  @Benchmark
+  def largeSameJaroWinklerTest(): Unit = largeSameArrTest(ArrayDistance.JaroWinkler)
+
+  @Benchmark
+  def emptyLevenshteinTest(): Unit = emptyArrTest(ArrayDistance.Levenshtein)
+  @Benchmark
+  def smallDiffLevenshteinTest(): Unit = smallDiffArrTest(ArrayDistance.Levenshtein)
+  @Benchmark
+  def smallSameLevenshteinTest(): Unit = smallSameArrTest(ArrayDistance.Levenshtein)
+  @Benchmark
+  def largeDiffLevenshteinTest(): Unit = largeDiffArrTest(ArrayDistance.Levenshtein)
+  @Benchmark
+  def largeSameLevenshteinTest(): Unit = largeSameArrTest(ArrayDistance.Levenshtein)
+
+  @Benchmark
   def emptyLongestCommonSeqTest(): Unit = emptyArrTest(ArrayDistance.LongestCommonSeq)
   @Benchmark
   def smallDiffLongestCommonSeqTest(): Unit = smallDiffArrTest(ArrayDistance.LongestCommonSeq)
@@ -54,17 +103,82 @@ class ArrayDistanceBenchmarks {
   @Benchmark
   def largeSameLongestCommonSeqTest(): Unit = largeSameArrTest(ArrayDistance.LongestCommonSeq)*/
 
-  // Missing: NeedlemanWunsch
+  @Benchmark
+  def emptyNeedlemanWunschTest(): Unit = emptyArrTest(ArrayDistance.NeedlemanWunsch)
+  @Benchmark
+  def smallDiffNeedlemanWunschTest(): Unit = smallDiffArrTest(ArrayDistance.NeedlemanWunsch)
+  @Benchmark
+  def smallSameNeedlemanWunschTest(): Unit = smallSameArrTest(ArrayDistance.NeedlemanWunsch)
+  @Benchmark
+  def largeDiffNeedlemanWunschTest(): Unit = largeDiffArrTest(ArrayDistance.NeedlemanWunsch)
+  @Benchmark
+  def largeSameNeedlemanWunschTest(): Unit = largeSameArrTest(ArrayDistance.NeedlemanWunsch)
 
-  // Missing: NGram
+  @Benchmark
+  def emptyNGramDistTest(): Unit = emptyArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def smallDiffNGramDistTest(): Unit = smallDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def smallSameNGramDistTest(): Unit = smallSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def largeDiffNGramDistTest(): Unit = largeDiffArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def largeSameNGramDistTest(): Unit = largeSameArrTest[ArrayDistance.WeightedDistanceMetric[Int]](ArrayDistance.NGram)
+
+  @Benchmark
+  def emptyNGramScoreTest(): Unit = emptyArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def smallDiffNGramScoreTest(): Unit = smallDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def smallSameNGramScoreTest(): Unit = smallSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def largeDiffNGramScoreTest(): Unit = largeDiffArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+  @Benchmark
+  def largeSameNGramScoreTest(): Unit = largeSameArrTest[ArrayDistance.WeightedScoreMetric[Int]](ArrayDistance.NGram)
+
+  @Benchmark
+  def emptyOverlapTest(): Unit = emptyArrTest(ArrayDistance.Overlap)
+  @Benchmark
+  def smallDiffOverlapTest(): Unit = smallDiffArrTest(ArrayDistance.Overlap)
+  @Benchmark
+  def smallSameOverlapTest(): Unit = smallSameArrTest(ArrayDistance.Overlap)
+  @Benchmark
+  def largeDiffOverlapTest(): Unit = largeDiffArrTest(ArrayDistance.Overlap)
+  @Benchmark
+  def largeSameOverlapTest(): Unit = largeSameArrTest(ArrayDistance.Overlap)
   
-  // Missing: Overlap
+  @Benchmark
+  def emptySmithWatermanTest(): Unit = emptyArrTest(ArrayDistance.SmithWaterman)
+  @Benchmark
+  def smallDiffSmithWatermanTest(): Unit = smallDiffArrTest(ArrayDistance.SmithWaterman)
+  @Benchmark
+  def smallSameSmithWatermanTest(): Unit = smallSameArrTest(ArrayDistance.SmithWaterman)
+  @Benchmark
+  def largeDiffSmithWatermanTest(): Unit = largeDiffArrTest(ArrayDistance.SmithWaterman)
+  @Benchmark
+  def largeSameSmithWatermanTest(): Unit = largeSameArrTest(ArrayDistance.SmithWaterman)
   
-  // Missing: SmithWaterman
+  @Benchmark
+  def emptySmithWatermanGotohTest(): Unit = emptyArrTest(ArrayDistance.SmithWatermanGotoh)
+  @Benchmark
+  def smallDiffSmithWatermanGotohTest(): Unit = smallDiffArrTest(ArrayDistance.SmithWatermanGotoh)
+  @Benchmark
+  def smallSameSmithWatermanGotohTest(): Unit = smallSameArrTest(ArrayDistance.SmithWatermanGotoh)
+  @Benchmark
+  def largeDiffSmithWatermanGotohTest(): Unit = largeDiffArrTest(ArrayDistance.SmithWatermanGotoh)
+  @Benchmark
+  def largeSameSmithWatermanGotohTest(): Unit = largeSameArrTest(ArrayDistance.SmithWatermanGotoh)
   
-  // Missing: SmithWatermanGotoh
-  
-  // Missing: Tversy
+  @Benchmark
+  def emptyTverskyTest(): Unit = emptyArrTest(ArrayDistance.Tversky)
+  @Benchmark
+  def smallDiffTverskyTest(): Unit = smallDiffArrTest(ArrayDistance.Tversky)
+  @Benchmark
+  def smallSameTverskyTest(): Unit = smallSameArrTest(ArrayDistance.Tversky)
+  @Benchmark
+  def largeDiffTverskyTest(): Unit = largeDiffArrTest(ArrayDistance.Tversky)
+  @Benchmark
+  def largeSameTverskyTest(): Unit = largeSameArrTest(ArrayDistance.Tversky)
 }
 
 object ArrayDistanceBenchmarks {
@@ -83,6 +197,21 @@ object ArrayDistanceBenchmarks {
   }
 
   implicit def distanceMetricBenchmarkable[T <: ArrayDistance.DistanceMetric] = new Bench[T] {
+    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+      metric.distance(arr1, arr2)
+  }
+
+  implicit def weightedScoreMetricBenchmarkable[T <: ArrayDistance.WeightedScoreMetric[_]] = new Bench[T] {
+    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+      metric.score(arr1, arr2)
+  }
+
+  implicit def weightedDistanceMetricBenchmarkable[T <: ArrayDistance.WeightedDistanceMetric[_]] = new Bench[T] {
+    def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
+      metric.distance(arr1, arr2)
+  }
+
+  implicit def scoreFromDistanceMetricBenchmarkable[T <: ArrayDistance.ScoreFromDistanceMetric] = new Bench[T] {
     def benchmark[U](arr1: Array[U], arr2: Array[U], metric: T): Unit =
       metric.distance(arr1, arr2)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -1,41 +1,55 @@
 import xerial.sbt.Sonatype._
 
-name := "stringdistance"
-version := "1.2.4-SNAPSHOT"
-scalaVersion := "2.13.1"
-organization := "com.github.vickumar1981"
-description := "A fuzzy matching string distance library for Scala and Java."
-sonatypeProjectHosting := Some(GitHubHosting("vickumar1981", "stringdistance", "vickumar@gmail.com"))
-publishMavenStyle := true
-licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
-pomIncludeRepository := { _ => false }
-publishArtifact in Test := false
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1")
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = false)
-
-// Add sonatype repository settings
-publishTo := Some(
-  if (isSnapshot.value)
-    Opts.resolver.sonatypeSnapshots
-  else
-    Opts.resolver.sonatypeStaging
-)
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-assemblyJarName := "stringdistance_2.13-" + version.value + ".jar"
-test in assembly := {}
-
-libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.0-M4" % Test
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.0-M4" % Test
-
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")
 testScalastyle := scalastyle.in(Test).toTask("").value
 (test in Test) := ((test in Test) dependsOn testScalastyle).value
 
-coverageExcludedPackages := "<empty>;.*stringdistance.impl.*Gap"
+lazy val commonSettings = List(
+    scalaVersion := "2.13.1",
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1"),
+)
 
-coverageEnabled in(Test, compile) := true
-coverageEnabled in(Compile, compile) := false
-coverageMinimum := 94
-coverageFailOnMinimum := true
-scalastyleFailOnWarning := true
+lazy val root = (project in file("."))
+  .settings(commonSettings: _*)
+  .settings(
+    name := "stringdistance",
+    version := "1.2.4-SNAPSHOT",
+    organization := "com.github.vickumar1981",
+    description := "A fuzzy matching string distance library for Scala and Java.",
+    sonatypeProjectHosting := Some(GitHubHosting("vickumar1981", "stringdistance", "vickumar@gmail.com")),
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+    pomIncludeRepository := { _ => false },
+    assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = false),
+
+    // Add sonatype repository settings
+    publishTo := Some(
+      if (isSnapshot.value)
+        Opts.resolver.sonatypeSnapshots
+      else
+        Opts.resolver.sonatypeStaging
+    ),
+    credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
+
+    assemblyJarName := "stringdistance_2.13-" + version.value + ".jar",
+    test in assembly := {},
+
+    libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.0-M4" % Test,
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.0-M4" % Test,
+    coverageExcludedPackages := "<empty>;.*stringdistance.impl.*Gap",
+
+    coverageEnabled in(Test, compile) := true,
+    coverageEnabled in(Compile, compile) := false,
+    coverageMinimum := 94,
+    coverageFailOnMinimum := true,
+    scalastyleFailOnWarning := true
+  )
+
+lazy val bench = (project in file("bench"))
+  .dependsOn(root)
+  .settings(commonSettings: _*)
+  .settings(
+    name := "stringdistance-benchmarks"
+  )
+  .enablePlugins(JmhPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 import xerial.sbt.Sonatype._
 
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")
-testScalastyle := scalastyle.in(Test).toTask("").value
-(test in Test) := ((test in Test) dependsOn testScalastyle).value
 
 lazy val commonSettings = List(
     scalaVersion := "2.13.1",
@@ -34,6 +32,9 @@ lazy val root = (project in file("."))
 
     assemblyJarName := "stringdistance_2.13-" + version.value + ".jar",
     test in assembly := {},
+
+    testScalastyle := scalastyle.in(Test).toTask("").value,
+    (test in Test) := ((test in Test) dependsOn testScalastyle).value,
 
     libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.0-M4" % Test,
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.0-M4" % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")


### PR DESCRIPTION
As a follow-up to https://github.com/vickumar1981/stringdistance/pull/58#pullrequestreview-517270531, this PR adds some JMH benchmarks to the `ArrayDistance` methods.

Here are the results of running `jmh:run -i 1 -wi 1 -f1 -t1` on my 2015 MacBook Pro.

```
Benchmark                                                 Mode  Cnt          Score   Error  Units
ArrayDistanceBenchmarks.largeDiffCosineTest              thrpt          441039.885          ops/s
ArrayDistanceBenchmarks.largeDiffDamerauTest             thrpt           18397.840          ops/s
ArrayDistanceBenchmarks.largeDiffDiceCoefficientTest     thrpt          613988.840          ops/s
ArrayDistanceBenchmarks.largeDiffHammingTest             thrpt         1104132.741          ops/s
ArrayDistanceBenchmarks.largeDiffJaccardTest             thrpt           30540.841          ops/s
ArrayDistanceBenchmarks.largeDiffJaroTest                thrpt            6444.788          ops/s
ArrayDistanceBenchmarks.largeDiffJaroWinklerTest         thrpt            6424.645          ops/s
ArrayDistanceBenchmarks.largeDiffLevenshteinTest         thrpt           11487.328          ops/s
ArrayDistanceBenchmarks.largeDiffNGramDistTest           thrpt           30818.115          ops/s
ArrayDistanceBenchmarks.largeDiffNGramScoreTest          thrpt           30233.446          ops/s
ArrayDistanceBenchmarks.largeDiffNeedlemanWunschTest     thrpt           17569.708          ops/s
ArrayDistanceBenchmarks.largeDiffOverlapTest             thrpt           30068.981          ops/s
ArrayDistanceBenchmarks.largeDiffSmithWatermanGotohTest  thrpt           17950.350          ops/s
ArrayDistanceBenchmarks.largeDiffSmithWatermanTest       thrpt            1425.146          ops/s
ArrayDistanceBenchmarks.largeDiffTverskyTest             thrpt           13631.024          ops/s
ArrayDistanceBenchmarks.largeSameCosineTest              thrpt          469210.378          ops/s
ArrayDistanceBenchmarks.largeSameDamerauTest             thrpt           18371.691          ops/s
ArrayDistanceBenchmarks.largeSameDiceCoefficientTest     thrpt          607873.432          ops/s
ArrayDistanceBenchmarks.largeSameHammingTest             thrpt         1197847.588          ops/s
ArrayDistanceBenchmarks.largeSameJaccardTest             thrpt           82927.656          ops/s
ArrayDistanceBenchmarks.largeSameJaroTest                thrpt           99501.217          ops/s
ArrayDistanceBenchmarks.largeSameJaroWinklerTest         thrpt           92704.896          ops/s
ArrayDistanceBenchmarks.largeSameLevenshteinTest         thrpt           12271.563          ops/s
ArrayDistanceBenchmarks.largeSameNGramDistTest           thrpt           82664.286          ops/s
ArrayDistanceBenchmarks.largeSameNGramScoreTest          thrpt           83175.825          ops/s
ArrayDistanceBenchmarks.largeSameNeedlemanWunschTest     thrpt         1757868.805          ops/s
ArrayDistanceBenchmarks.largeSameOverlapTest             thrpt           82676.886          ops/s
ArrayDistanceBenchmarks.largeSameSmithWatermanGotohTest  thrpt           19145.435          ops/s
ArrayDistanceBenchmarks.largeSameSmithWatermanTest       thrpt            1489.250          ops/s
ArrayDistanceBenchmarks.largeSameTverskyTest             thrpt           81298.891          ops/s
ArrayDistanceBenchmarks.smallDiffCosineTest              thrpt         1048530.501          ops/s
ArrayDistanceBenchmarks.smallDiffDamerauTest             thrpt          393984.004          ops/s
ArrayDistanceBenchmarks.smallDiffDiceCoefficientTest     thrpt         1788681.339          ops/s
ArrayDistanceBenchmarks.smallDiffHammingTest             thrpt         4260911.428          ops/s
ArrayDistanceBenchmarks.smallDiffJaccardTest             thrpt          276966.223          ops/s
ArrayDistanceBenchmarks.smallDiffJaroTest                thrpt          403614.692          ops/s
ArrayDistanceBenchmarks.smallDiffJaroWinklerTest         thrpt          376493.104          ops/s
ArrayDistanceBenchmarks.smallDiffLevenshteinTest         thrpt          263856.976          ops/s
ArrayDistanceBenchmarks.smallDiffLongestCommonSeqTest    thrpt             432.280          ops/s
ArrayDistanceBenchmarks.smallDiffNGramDistTest           thrpt          283573.382          ops/s
ArrayDistanceBenchmarks.smallDiffNGramScoreTest          thrpt          282893.455          ops/s
ArrayDistanceBenchmarks.smallDiffNeedlemanWunschTest     thrpt          340344.335          ops/s
ArrayDistanceBenchmarks.smallDiffOverlapTest             thrpt          277022.468          ops/s
ArrayDistanceBenchmarks.smallDiffSmithWatermanGotohTest  thrpt          385030.029          ops/s
ArrayDistanceBenchmarks.smallDiffSmithWatermanTest       thrpt          156275.448          ops/s
ArrayDistanceBenchmarks.smallDiffTverskyTest             thrpt          211475.612          ops/s
ArrayDistanceBenchmarks.smallSameCosineTest              thrpt         1129606.449          ops/s
ArrayDistanceBenchmarks.smallSameDamerauTest             thrpt          375486.316          ops/s
ArrayDistanceBenchmarks.smallSameDiceCoefficientTest     thrpt         1147438.239          ops/s
ArrayDistanceBenchmarks.smallSameHammingTest             thrpt         4079188.236          ops/s
ArrayDistanceBenchmarks.smallSameJaccardTest             thrpt         1390518.064          ops/s
ArrayDistanceBenchmarks.smallSameJaroTest                thrpt          551722.743          ops/s
ArrayDistanceBenchmarks.smallSameJaroWinklerTest         thrpt          589250.679          ops/s
ArrayDistanceBenchmarks.smallSameLevenshteinTest         thrpt          246561.757          ops/s
ArrayDistanceBenchmarks.smallSameLongestCommonSeqTest    thrpt         9078936.082          ops/s
ArrayDistanceBenchmarks.smallSameNGramDistTest           thrpt         1428757.599          ops/s
ArrayDistanceBenchmarks.smallSameNGramScoreTest          thrpt         1411156.069          ops/s
ArrayDistanceBenchmarks.smallSameNeedlemanWunschTest     thrpt         6126023.083          ops/s
ArrayDistanceBenchmarks.smallSameOverlapTest             thrpt         1401205.916          ops/s
ArrayDistanceBenchmarks.smallSameSmithWatermanGotohTest  thrpt          381707.698          ops/s
ArrayDistanceBenchmarks.smallSameSmithWatermanTest       thrpt          161300.496          ops/s
ArrayDistanceBenchmarks.smallSameTverskyTest             thrpt         1255910.582          ops/s
```

I had to disable the `large*LongestCommonSeqTest`, since those took a very long time to run.