### PR TITLE
Fix runtime complexity of LongestCommonSeqImpl.scala

### DIFF
--- a/src/main/scala/com/github/vickumar1981/stringdistance/impl/LongestCommonSeqImpl.scala
+++ b/src/main/scala/com/github/vickumar1981/stringdistance/impl/LongestCommonSeqImpl.scala
@@ -2,18 +2,17 @@ package com.github.vickumar1981.stringdistance.impl
 
 private[stringdistance] trait LongestCommonSeqImpl {
   protected def longestCommonSeq[T](s1: Array[T], s2: Array[T]): Int = {
-    val m = s1.length
-    val n = s2.length
-    val T = Array.ofDim[Int](m + 1, n + 1)
-    for (i <- 1 to m) {
-      for (j <- 1 to n) {
+    val (s1Len, s2Len) = (s1.length, s2.length)
+    val dist = Array.ofDim[Int](s1Len + 1, s2Len + 1)
+    for (i <- 1 to s1Len) {
+      for (j <- 1 to s2Len) {
         if (s1(i - 1) == s2(j - 1)) {
-          T(i)(j) = T(i - 1)(j - 1) + 1
+          dist(i)(j) = dist(i - 1)(j - 1) + 1
         } else {
-          T(i)(j) = math.max(T(i - 1)(j), T(i)(j - 1))
+          dist(i)(j) = math.max(dist(i - 1)(j), dist(i)(j - 1))
         }
       }
     }
-    T(m)(n)
+    dist(s1Len)(s2Len)
   }
 }

--- a/src/main/scala/com/github/vickumar1981/stringdistance/impl/LongestCommonSeqImpl.scala
+++ b/src/main/scala/com/github/vickumar1981/stringdistance/impl/LongestCommonSeqImpl.scala
@@ -1,12 +1,19 @@
 package com.github.vickumar1981.stringdistance.impl
 
 private[stringdistance] trait LongestCommonSeqImpl {
-  private def lcs[T](x: Array[T], y: Array[T], m: Int, n: Int): Int = {
-    if (m == 0 || n == 0) 0
-    else if (x(m - 1) == y(n - 1)) 1 + lcs(x, y, m - 1, n - 1)
-    else math.max(lcs(x, y, m, n - 1), lcs(x, y, m - 1, n))
+  protected def longestCommonSeq[T](s1: Array[T], s2: Array[T]): Int = {
+    val m = s1.length
+    val n = s2.length
+    val T = Array.ofDim[Int](m + 1, n + 1)
+    for (i <- 1 to m) {
+      for (j <- 1 to n) {
+        if (s1(i - 1) == s2(j - 1)) {
+          T(i)(j) = T(i - 1)(j - 1) + 1
+        } else {
+          T(i)(j) = math.max(T(i - 1)(j), T(i)(j - 1))
+        }
+      }
+    }
+    T(m)(n)
   }
-
-  protected def longestCommonSeq[T](s1: Array[T], s2: Array[T]): Int =
-    lcs(s1, s2, s1.length, s2.length)
 }

--- a/src/test/scala/fixtures/TestCases.scala
+++ b/src/test/scala/fixtures/TestCases.scala
@@ -112,7 +112,8 @@ object TestCases {
       Some(1),
       Some(1),
       ngram = Some(1),
-      nGramDist = Some(0))
+      nGramDist = Some(0)),
+    TestCase("RUE NELSON MANDELA", "RUE ALBERT UNGEHEUER", longestCommonSeq = Some(8))
   )
 
   lazy val precision = 3


### PR DESCRIPTION
- Reduces runtime complexity of `LongestCommonSeq` for two arrays, `n`, and `m` to `O(n*m)`
- Addresses: https://github.com/vickumar1981/stringdistance/issues/64